### PR TITLE
Task 2 order routes

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -60,7 +60,7 @@ const getByCustomer = async (req, res) => {
 
 const getByStatus = async (req, res) => {
   try {
-    const orders = await Order.getByStatus(req.params.status);
+    const orders = await Order.getByStatus(req.query.s);
     res.send(orders);
   } catch (error) {
     res.status(500).send(error);

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -67,6 +67,15 @@ const getByStatus = async (req, res) => {
   }
 };
 
+const getTotalSales = async (req, res) => {
+  try {
+    const totalSales = await Order.getTotalSales(req.body);
+    res.send(totalSales);
+  } catch (error) {
+    res.status(500).send(error);
+  }
+};
+
 module.exports = {
   getAll,
   getOne,
@@ -74,5 +83,6 @@ module.exports = {
   update,
   remove,
   getByCustomer,
-  getByStatus
+  getByStatus,
+  getTotalSales
 };

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -3,8 +3,12 @@ const orderController = require("../controllers/orderController");
 
 const orderRouter = Router();
 
+// Get total sales route
+orderRouter.get("/total-sales", orderController.getTotalSales);
+
 orderRouter.get("/", orderController.getAll);
 orderRouter.get("/:id", orderController.getOne);
+
 orderRouter.post("/", orderController.create);
 orderRouter.put("/:id", orderController.update);
 orderRouter.delete("/:id", orderController.remove);

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -6,6 +6,9 @@ const orderRouter = Router();
 // Get total sales route
 orderRouter.get("/total-sales", orderController.getTotalSales);
 
+// Get order by status route
+orderRouter.get("/status", orderController.getByStatus);
+
 orderRouter.get("/", orderController.getAll);
 orderRouter.get("/:id", orderController.getOne);
 


### PR DESCRIPTION
Added to 2 new endpoints

1. Total Sales Route - this route returns the total sales of all orders, regardless of order status, in the form of an object with the "total" key. An optional startDate and endDate can be passed in as arguments. To test the endpoint (http://localhost:3001/api/orders/total-sales) with startDate and endDate using Postman, please add the following in the request body, 

```
{
    "startDate": "2022-01",
    "endDate": "2022-05"
}
``` 

The endpoint should return a total of $64. If no argument is passed, it should return a total of $141.

2. Order By Status Route - this route returns all orders with the status that matches the query parameter in an array.